### PR TITLE
Break up long sentence before sending to kokoro

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="c@aedo.dev",
     url="https://github.com/aedocw/epub2tts-kokoro",
     license="GPL 3.0",
-    version="1.1.0",
+    version="1.1.1",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
When kokoro receives very long sentences, it reads them but rushes through them. I'm not really sure what constitutes "very long" but it seems like around 350 characters or so. This PR tries to break up long sentences into shorter chunks, breaking at a comma when possible.