### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ nltk
 numpy
 pillow
 pydub
-setuptools
+setuptools==79.0.1
 soundfile
 tqdm


### PR DESCRIPTION
The new version 80.0.0 of setuptools deprecates something and makes it impossible to compile packages using pip